### PR TITLE
Implement option for aggregating field transfers across groups of MPI tasks

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -165,6 +165,18 @@ program smiol_runner
         write(test_log,'(a)') ''
     endif
 
+    !
+    ! Unit tests for I/O aggregation
+    !
+    ierr = test_io_aggregation(test_log)
+    if (ierr == 0) then
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
+    else
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
+    endif
+
     num_io_tasks = 16
     io_stride = 4
 
@@ -2961,6 +2973,331 @@ contains
         write(test_log,'(a)') ''
 
     end function test_put_get_var
+
+
+    function test_io_aggregation(test_log) result(ierrcount)
+
+        implicit none
+
+        integer, intent(in) :: test_log
+        integer :: ierrcount
+
+        integer(kind=c_size_t) :: i, j
+        integer :: ierr
+        integer :: comm_size, comm_rank
+        type (SMIOLf_context), pointer :: context
+        integer :: num_io_tasks, io_stride
+        integer(kind=c_size_t) :: n_compute_elements, n_total, offset
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: compute_elements
+        type (SMIOLf_decomp), pointer :: decomp_noagg, decomp_agg2, decomp_agg0
+        type (SMIOLf_file), pointer :: file
+        character(len=32), dimension(2) :: dimnames
+        real, dimension(:,:), pointer :: theta1, theta2
+        logical :: all_equal
+
+
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '*************************** I/O aggregation tests ******************************'
+        write(test_log,'(a)') ''
+
+        ierrcount = 0
+
+        call MPI_Comm_rank(MPI_COMM_WORLD, comm_rank, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI rank...'
+            ierrcount = -1
+            return
+        end if
+
+        call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI size...'
+            ierrcount = -1
+            return
+        end if
+
+        num_io_tasks = comm_size
+        io_stride = 1
+
+        !
+        ! Create a SMIOL context for testing aggregation
+        !
+        ierr = SMIOLf_init(MPI_COMM_WORLD, num_io_tasks, io_stride, context)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
+            write(test_log,'(a)') 'Failed to initalize a SMIOL context'
+            ierrcount = -1
+            return
+        end if
+
+        !
+        ! Define compute elements for all tasks
+        !
+        n_compute_elements = 10 + comm_rank    ! Give each task a different number... why not?
+
+        ! Total number of compute elements across all tasks
+        n_total = 10 * comm_size + (comm_size * (comm_size - 1)) / 2
+
+        ! Offset for contiguous range of elements computed on this task
+        offset = 10 * comm_rank + (comm_rank * (comm_rank - 1)) / 2
+
+        allocate(compute_elements(n_compute_elements))
+
+        ! Tasks compute contiguous ranges of elements in reverse order
+        do i = 1, n_compute_elements
+            compute_elements(i) = n_total - (offset + i)
+        end do
+
+        !
+        ! Create three decompositions: one that does not use aggregation, one that uses
+        ! an aggregation factor of two, and one that specifies an aggregation factor of 0
+        !
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp_noagg, aggregation_factor=1) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create a decomp with aggregation_factor=1'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp_agg2, aggregation_factor=2) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create a decomp with aggregation_factor=2'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp_agg0, aggregation_factor=0) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create a decomp with aggregation_factor=0'
+            ierrcount = -1
+            return
+        end if
+
+        !
+        ! Create a new file, to which we will write using all three of the decompositions from above
+        !
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'test_agg_f.nc', SMIOL_FILE_CREATE, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to create a file for testing aggregation'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'nCells', int(n_total, kind=SMIOL_offset_kind)) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension nCells...'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'nVertLevels', 55_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension nVertLevels...'
+            ierrcount = -1
+            return
+        end if
+
+        ! The theta_noagg variable will be written with no aggregation and later read with aggregation
+        dimnames(1) = 'nVertLevels'
+        dimnames(2) = 'nCells'
+        if (SMIOLf_define_var(file, 'theta_noagg', SMIOL_REAL32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create theta_noagg var...'
+            ierrcount = -1
+            return
+        end if
+
+        ! The theta_agg2 variable will be written with aggregation=2 and later read without aggregation
+        dimnames(1) = 'nVertLevels'
+        dimnames(2) = 'nCells'
+        if (SMIOLf_define_var(file, 'theta_agg2', SMIOL_REAL32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create theta_agg2 var...'
+            ierrcount = -1
+            return
+        end if
+
+        ! The theta_agg0 variable will be written with aggregation=0 and later read with aggregation=2
+        dimnames(1) = 'nVertLevels'
+        dimnames(2) = 'nCells'
+        if (SMIOLf_define_var(file, 'theta_agg0', SMIOL_REAL32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create theta_agg0 var...'
+            ierrcount = -1
+            return
+        end if
+
+        !
+        ! Write a simple pattern to the theta field
+        !
+        allocate(theta1(55, n_compute_elements))
+
+        do j = 1, n_compute_elements
+            do i = 1, 55
+                theta1(i, j) = real(55 * compute_elements(j) + i)
+            end do
+        end do
+
+        deallocate(compute_elements)
+
+        ! Writing a field with a no-aggregation decomp
+        write(test_log,'(a)',advance='no') 'Write a field with a decomp that does not use aggregation: '
+        ierr = SMIOLf_put_var(file, 'theta_noagg', decomp_noagg, theta1)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_put_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Writing a field with aggregation=2 decomp
+        write(test_log,'(a)',advance='no') 'Write a field with a decomp that uses aggregation factor 2: '
+        ierr = SMIOLf_put_var(file, 'theta_agg2', decomp_agg2, theta1)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_put_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Writing a field with aggregation=0 decomp
+        write(test_log,'(a)',advance='no') 'Write a field with a decomp that uses aggregation factor 0: '
+        ierr = SMIOLf_put_var(file, 'theta_agg0', decomp_agg0, theta1)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_put_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to close file for aggregregation tests'
+            ierrcount = -1
+            return
+        end if
+
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'test_agg_f.nc', SMIOL_FILE_READ, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to open file that was created for testing aggregation'
+            ierrcount = -1
+            return
+        end if
+
+        allocate(theta2(55, n_compute_elements))
+
+        ! Read a field that was written with aggregation=2 using a no-aggregation decomp
+        write(test_log,'(a)',advance='no') 'Read field written with aggregation=2 using no aggregation: '
+        theta2(:,:) = -1.0
+        ierr = SMIOLf_get_var(file, 'theta_agg2', decomp_noagg, theta2)
+        if (ierr == SMIOL_SUCCESS) then
+            ! Compare with theta1, which still contains the correct field
+            all_equal = .true.
+            AGG_COMP_LOOP1: do j = 1, n_compute_elements
+                do i = 1, 55
+                    if (theta1(i, j) /= theta2(i, j)) then
+                        all_equal = .false.
+                        exit AGG_COMP_LOOP1
+                    end if
+                end do
+            end do AGG_COMP_LOOP1
+
+            if (all_equal) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - The field was read with incorrect values'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_get_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Read a field that was written with no aggregation using an aggregation=0 decomp
+        write(test_log,'(a)',advance='no') 'Read field written with no aggregation using aggregation=0: '
+        theta2(:,:) = -1.0
+        ierr = SMIOLf_get_var(file, 'theta_noagg', decomp_agg0, theta2)
+        if (ierr == SMIOL_SUCCESS) then
+            ! Compare with theta1, which still contains the correct field
+            all_equal = .true.
+            AGG_COMP_LOOP2: do j = 1, n_compute_elements
+                do i = 1, 55
+                    if (theta1(i, j) /= theta2(i, j)) then
+                        all_equal = .false.
+                        exit AGG_COMP_LOOP2
+                    end if
+                end do
+            end do AGG_COMP_LOOP2
+
+            if (all_equal) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - The field was read with incorrect values'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_get_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Read a field that was written with aggregation=0 using an aggregation=2 decomp
+        write(test_log,'(a)',advance='no') 'Read field written with aggregation=0 using aggregation=2: '
+        theta2(:,:) = -1.0
+        ierr = SMIOLf_get_var(file, 'theta_agg0', decomp_agg2, theta2)
+        if (ierr == SMIOL_SUCCESS) then
+            ! Compare with theta1, which still contains the correct field
+            all_equal = .true.
+            AGG_COMP_LOOP3: do j = 1, n_compute_elements
+                do i = 1, 55
+                    if (theta1(i, j) /= theta2(i, j)) then
+                        all_equal = .false.
+                        exit AGG_COMP_LOOP3
+                    end if
+                end do
+            end do AGG_COMP_LOOP3
+
+            if (all_equal) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - The field was read with incorrect values'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned by SMIOLf_get_var'
+            ierrcount = ierrcount + 1
+        end if
+
+        if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to close file for aggregregation tests'
+            ierrcount = -1
+            return
+        end if
+
+        deallocate(theta1)
+        deallocate(theta2)
+
+        if (SMIOLf_free_decomp(decomp_noagg) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free decomp_noagg'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_free_decomp(decomp_agg2) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free decomp_agg2'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_free_decomp(decomp_agg0) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free decomp_agg0'
+            ierrcount = -1
+            return
+        end if
+
+        ierr = SMIOLf_finalize(context)
+        if (ierr /= SMIOL_SUCCESS .or. associated(context)) then
+            ierrcount = -1
+            return
+        end if
+
+        write(test_log,'(a)') ''
+
+    end function test_io_aggregation
 
 
     !-----------------------------------------------------------------------

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -183,7 +183,7 @@ program smiol_runner
     compute_elements(:) = 0
 
     if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, &
-                             decomp) /= SMIOL_SUCCESS) then
+                             decomp, aggregation_factor=1) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "Error: SMIOLf_create_decomp was not called successfully"
         stop 1
     endif
@@ -675,7 +675,7 @@ contains
         write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp with 0 elements: '
         n_compute_elements = 0
         allocate(compute_elements(n_compute_elements))
-        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else
@@ -703,7 +703,7 @@ contains
         n_compute_elements = 1
         allocate(compute_elements(n_compute_elements))
         compute_elements(:) = 0
-        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else
@@ -731,7 +731,7 @@ contains
         n_compute_elements = 1000000
         allocate(compute_elements(n_compute_elements))
         compute_elements(:) = 0
-        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else
@@ -804,7 +804,7 @@ contains
                 end do
             end if
 
-            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
             if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
 
                 ! The correct comp_list and io_list arrays, below, were verified manually
@@ -868,7 +868,7 @@ contains
                 end do
             end if
 
-            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
             if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
 
                 ! The correct comp_list and io_list arrays, below, were verified manually
@@ -934,7 +934,7 @@ contains
                 end do
             end if
 
-            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp)
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1)
             if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
 
                 ! The correct comp_list and io_list arrays, below, were verified manually
@@ -2628,7 +2628,8 @@ contains
                 endif
             enddo
 
-            if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp) /= SMIOL_SUCCESS) then
+            if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, decomp, aggregation_factor=1) &
+                /= SMIOL_SUCCESS) then
                 write(test_log,'(a)') "FAIL: SMIOLf_create_decomp was not called successfully"
                 ierrcount = -1
                 return

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -318,7 +318,7 @@ int main(int argc, char **argv)
 
 	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
 
-	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements,
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1,
 	                           &decomp);
 	if (ierr != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_create_decomp - SMIOL_SUCCESS was not returned\n");
@@ -834,7 +834,7 @@ int test_decomp(FILE *test_log)
 	/* Test create decomp with compute_elements == NULL and n_compute != 0 */
 	fprintf(test_log, "Testing SMIOL_create_decomp with NULL elements and n_elements != 0: ");
 	n_compute_elements = 1;
-	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 	if (ierr == SMIOL_INVALID_ARGUMENT && decomp == NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
@@ -859,7 +859,7 @@ int test_decomp(FILE *test_log)
 	fprintf(test_log, "Everything OK (SMIOL_create_decomp) with 0 elements: ");
 	n_compute_elements = 0;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
-	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
@@ -891,7 +891,7 @@ int test_decomp(FILE *test_log)
 	n_compute_elements = 1;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
-	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
@@ -922,7 +922,7 @@ int test_decomp(FILE *test_log)
 	n_compute_elements = 1000000;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
-	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
@@ -996,7 +996,7 @@ int test_decomp(FILE *test_log)
 				compute_elements[i] = (SMIOL_Offset)(2 * i);        /* Even elements */
 			}
 		}
-		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 
 			/* The correct comp_list and io_list arrays, below, were verified manually */
@@ -1060,7 +1060,7 @@ int test_decomp(FILE *test_log)
 				compute_elements[i] = (SMIOL_Offset)(2 * i + 1);    /* Odd elements */
 			}
 		}
-		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 
 			/* The correct comp_list and io_list arrays, below, were verified manually */
@@ -1126,7 +1126,7 @@ int test_decomp(FILE *test_log)
 				compute_elements[i] = (SMIOL_Offset)(n_compute_elements - 1 - i);    /* All compute elements */
 			}
 		}
-		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, &decomp);
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, 1, &decomp);
 		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 
 			/* The correct comp_list and io_list arrays, below, were verified manually */
@@ -4425,7 +4425,7 @@ int test_put_get_vars(FILE *test_log)
 			compute_elements[i] = comm_rank * (nCells / comm_size) + (SMIOL_Offset)i;
 		}
 		ierr = SMIOL_create_decomp(context,
-		                           n_compute_elements, compute_elements,
+		                           n_compute_elements, compute_elements, 1,
 		                           &decomp);
 		if (ierr != SMIOL_SUCCESS) {
 			fprintf(test_log, "Failed to create decomp...\n");
@@ -4441,7 +4441,7 @@ int test_put_get_vars(FILE *test_log)
 	/* Create a second decomp in which each task owns just one element */
 	compute_element = comm_rank;
 	ierr = SMIOL_create_decomp(context,
-	                           1, &compute_element,
+	                           1, &compute_element, 1,
 	                           &decomp2);
 	if (ierr != SMIOL_SUCCESS) {
 		fprintf(test_log, "Failed to create decomp2...\n");
@@ -4810,7 +4810,7 @@ int test_put_get_vars(FILE *test_log)
 			compute_elements[i] = comm_rank + comm_size * (SMIOL_Offset)i;
 		}
 		ierr = SMIOL_create_decomp(context,
-		                           n_compute_elements, compute_elements,
+		                           n_compute_elements, compute_elements, 1,
 		                           &decomp);
 		if (ierr != SMIOL_SUCCESS) {
 			fprintf(test_log, "Failed to create decomp...\n");

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -820,6 +820,10 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 	size_t *start;
 	size_t *count;
 
+	void *agg_buf = NULL;
+	const void *agg_buf_cnst = NULL;
+
+
 	/*
 	 * Basic checks on arguments
 	 */
@@ -852,13 +856,63 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 			return SMIOL_MALLOC_FAILURE;
 		}
 
+		if (decomp->agg_factor != 1) {
+			MPI_Datatype dtype;
+			MPI_Comm agg_comm;
+
+			ierr = MPI_Type_contiguous((int)element_size,
+			                           MPI_UINT8_T, &dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_contiguous failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_commit(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_commit failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_buf = malloc(element_size * decomp->n_compute_agg);
+			if (agg_buf == NULL && decomp->n_compute_agg > 0) {
+				return SMIOL_MALLOC_FAILURE;
+			}
+
+			agg_comm = MPI_Comm_f2c(decomp->agg_comm);
+
+			ierr = MPI_Gatherv((const void *)buf,
+			                   (int)decomp->n_compute, dtype,
+			                   (void *)agg_buf,
+			                   (const int *)decomp->counts,
+			                   (const int *)decomp->displs,
+			                   dtype, 0, agg_comm);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Gatherv failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_free(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_free failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_buf_cnst = agg_buf;
+		} else {
+			agg_buf_cnst = buf;
+		}
+
 		ierr = transfer_field(decomp, SMIOL_COMP_TO_IO,
-		                      element_size, buf, out_buf);
+		                      element_size, agg_buf_cnst, out_buf);
 		if (ierr != SMIOL_SUCCESS) {
 			free(start);
 			free(count);
 			free(out_buf);
 			return ierr;
+		}
+
+		if (decomp->agg_factor != 1) {
+			free(agg_buf);
 		}
 	}
 
@@ -1003,6 +1057,9 @@ int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
 	void *in_buf = NULL;
 	size_t *start;
 	size_t *count;
+
+	void *agg_buf = NULL;
+
 
 	/*
 	 * Basic checks on arguments
@@ -1155,8 +1212,57 @@ int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
 	 * be done for decomposed variables.
 	 */
 	if (decomp) {
+		if (decomp->agg_factor != 1) {
+			agg_buf = malloc(element_size * decomp->n_compute_agg);
+			if (agg_buf == NULL && decomp->n_compute_agg > 0) {
+				return SMIOL_MALLOC_FAILURE;
+			}
+		} else {
+			agg_buf = buf;
+		}
+
 		ierr = transfer_field(decomp, SMIOL_IO_TO_COMP,
-		                      element_size, in_buf, buf);
+		                      element_size, in_buf, agg_buf);
+
+		if (decomp->agg_factor != 1) {
+			MPI_Datatype dtype = MPI_DATATYPE_NULL;
+			MPI_Comm agg_comm;
+
+			ierr = MPI_Type_contiguous((int)element_size,
+			                           MPI_UINT8_T, &dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_contiguous failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			ierr = MPI_Type_commit(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_commit failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			agg_comm = MPI_Comm_f2c(decomp->agg_comm);
+
+			ierr = MPI_Scatterv((const void *)agg_buf,
+			                    (const int*)decomp->counts,
+			                    (const int *)decomp->displs,
+			                    dtype, (void *)buf,
+			                    (int)decomp->n_compute,
+			                    dtype, 0, agg_comm);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Scatterv failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+
+			free(agg_buf);
+
+			ierr = MPI_Type_free(&dtype);
+			if (ierr != MPI_SUCCESS) {
+				fprintf(stderr, "MPI_Type_free failed with code %i\n", ierr);
+				return SMIOL_MPI_ERROR;
+			}
+		}
+
 		free(in_buf);
 
 		if (ierr != SMIOL_SUCCESS) {
@@ -1608,6 +1714,13 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	MPI_Datatype dtype;
 	int ierr;
 
+	size_t n_compute_elements_agg;
+	SMIOL_Offset *compute_elements_agg = NULL;
+	MPI_Comm agg_comm = MPI_COMM_NULL;
+	int *counts = NULL;
+	int *displs = NULL;
+	int actual_agg_factor;
+
 
 	/*
 	 * Minimal check on the validity of arguments
@@ -1617,6 +1730,10 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	}
 
 	if (compute_elements == NULL && n_compute_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (aggregation_factor < 0) {
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
@@ -1676,14 +1793,78 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	}
 
 	/*
+	 * If aggregation_factor != 1, aggregate the list of compute_elements
+	 * before building the mapping
+	 */
+	if (aggregation_factor != 1) {
+		int comm_rank = context->comm_rank;
+
+		/*
+		 * Create intracommunicators for aggregation
+		 */
+		if (aggregation_factor == 0) {
+			ierr = MPI_Comm_split_type(comm, MPI_COMM_TYPE_SHARED,
+			                           comm_rank, MPI_INFO_NULL,
+			                           &agg_comm);
+		} else {
+			ierr = MPI_Comm_split(comm,
+			                      (comm_rank / aggregation_factor),
+			                      comm_rank,
+			                      &agg_comm);
+		}
+		if (ierr != MPI_SUCCESS) {
+			fprintf(stderr, "Error: MPI_Comm_split failed with code %i\n",
+			        ierr);
+			return SMIOL_MPI_ERROR;
+		}
+
+		ierr = MPI_Comm_size(agg_comm, &actual_agg_factor);
+		if (ierr != MPI_SUCCESS) {
+			fprintf(stderr, "Error: MPI_Comm_size failed with code %i\n",
+			        ierr);
+			return SMIOL_MPI_ERROR;
+		}
+
+		/*
+		 * Create aggregated compute_elements list if the actual
+		 * aggregation factor is > 1
+		 */
+		if (actual_agg_factor > 1) {
+			aggregate_list(agg_comm, 0, n_compute_elements,
+			               compute_elements,
+			               &n_compute_elements_agg,
+			               &compute_elements_agg, &counts, &displs);
+		} else {
+			MPI_Comm_free(&agg_comm);
+			n_compute_elements_agg = n_compute_elements;
+			compute_elements_agg = compute_elements;
+		}
+	} else {
+		actual_agg_factor = 1;
+		n_compute_elements_agg = n_compute_elements;
+		compute_elements_agg = compute_elements;
+	}
+
+	/*
 	 * Build the mapping between compute tasks and I/O tasks
 	 */
 	ierr = build_exchange(context,
-	                      n_compute_elements, compute_elements,
+	                      n_compute_elements_agg, compute_elements_agg,
 	                      io_count, io_elements,
 	                      decomp);
 
 	free(io_elements);
+
+	if (actual_agg_factor > 1) {
+		(*decomp)->agg_factor = actual_agg_factor;
+		(*decomp)->agg_comm = MPI_Comm_c2f(agg_comm);
+		(*decomp)->n_compute = n_compute_elements;
+		(*decomp)->n_compute_agg = n_compute_elements_agg;
+		(*decomp)->counts = counts;
+		(*decomp)->displs = displs;
+
+		free(compute_elements_agg);
+	}
 
 	/*
 	 * If decomp was successfully created, add io_start and io_count values

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1575,8 +1575,19 @@ int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame)
  *
  * Creates a mapping between compute elements and I/O elements.
  *
- * Given arrays of global element IDs that each task computes, this routine works
- * out a mapping of elements between compute and I/O tasks.
+ * Given arrays of global element IDs that each task computes, this routine
+ * works out a mapping of elements between compute and I/O tasks.
+ *
+ * The aggregation factor is used to indicate the size of subsets of ranks
+ * that will gather fields onto a single rank in each subset before transferring
+ * that field from compute to output tasks; in a symmetric way, it also
+ * indicates the size of subsets over which fields will be scattered after they
+ * are transferred from input tasks to a single compute tasks in each subset.
+ *
+ * An aggregation factor of 0 indicates that the implementation should choose
+ * a suitable aggregation factor (usually matching the size of shared-memory
+ * domains), while a positive integer specifies a specific size for task groups
+ * to be used for aggregation.
  *
  * If all input arguments are determined to be valid and if the routine is
  * successful in working out a mapping, the decomp pointer is allocated and
@@ -1586,6 +1597,7 @@ int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame)
  *******************************************************************************/
 int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        int aggregation_factor,
                         struct SMIOL_decomp **decomp)
 {
 	size_t i;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1699,12 +1699,26 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
  ********************************************************************************/
 int SMIOL_free_decomp(struct SMIOL_decomp **decomp)
 {
+	MPI_Comm comm;
+
 	if ((*decomp) == NULL) {
 		return SMIOL_SUCCESS;
 	}
 
 	free((*decomp)->comp_list);
 	free((*decomp)->io_list);
+
+	comm = MPI_Comm_f2c((*decomp)->agg_comm);
+	if (comm != MPI_COMM_NULL) {
+		MPI_Comm_free(&comm);
+	}
+	if ((*decomp)->counts != NULL) {
+		free((*decomp)->counts);
+	}
+	if ((*decomp)->displs != NULL) {
+		free((*decomp)->displs);
+	}
+
 	free((*decomp));
 	*decomp = NULL;
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -65,6 +65,7 @@ int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame);
  */
 int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        int aggregation_factor,
                         struct SMIOL_decomp **decomp);
 int SMIOL_free_decomp(struct SMIOL_decomp **decomp);
 

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -56,6 +56,14 @@ struct SMIOL_decomp {
 
 	size_t io_start;  /* The starting offset on disk for I/O by a task */
 	size_t io_count;  /* The number of elements for I/O by a task */
+
+	int agg_factor;        /* Aggregation factor, or size of aggregation group */
+	MPI_Fint agg_comm;     /* Communicator for aggregation/deaggregation operations */
+	size_t n_compute;      /* Number of un-aggregated compute elements on the task */
+	size_t n_compute_agg;  /* Number of aggregated compute elements on the task */
+	int *counts;           /* Compute element counts for tasks in aggregation group */
+	int *displs;           /* Displacements in aggregated list of elements for tasks */
+	                       /*    in aggregation group */
 };
 
 

--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -830,6 +830,12 @@ int build_exchange(struct SMIOL_context *context,
 	(*decomp)->io_list = NULL;
 	(*decomp)->io_start = 0;
 	(*decomp)->io_count = 0;
+	(*decomp)->agg_factor = 1;   /* Group with 1 task -> no aggregation */
+	(*decomp)->agg_comm = MPI_Comm_c2f(MPI_COMM_NULL);
+	(*decomp)->n_compute = 0;
+	(*decomp)->n_compute_agg = 0;
+	(*decomp)->counts = NULL;
+	(*decomp)->displs = NULL;
 
 
 	/*

--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -1096,6 +1096,46 @@ void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list)
 		}
 		j += n_elems;
 	}
+	fprintf(f, "\n\n");
+
+
+	fprintf(f, "SMIOL_Offset comp_list_correct[] = { ");
+	j = 0;
+	n_neighbors = comp_list[j++];
+	fprintf(f, "%i", (int)n_neighbors);
+
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = comp_list[j++];
+		fprintf(f, ", %i", (int)neighbor);
+
+		n_elems = comp_list[j++];
+		fprintf(f, ", %i", (int)n_elems);
+
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, ", %i", (int)comp_list[j+k]);
+		}
+		j += n_elems;
+	}
+	fprintf(f, " };\n");
+
+	fprintf(f, "SMIOL_Offset io_list_correct[] = { ");
+	j = 0;
+	n_neighbors = io_list[j++];
+	fprintf(f, "%i", (int)n_neighbors);
+
+	for (i = 0; i < n_neighbors; i++) {
+		neighbor = io_list[j++];
+		fprintf(f, ", %i", (int)neighbor);
+
+		n_elems = io_list[j++];
+		fprintf(f, ", %i", (int)n_elems);
+
+		for (k = 0; k < n_elems; k++) {
+			fprintf(f, ", %i", (int)io_list[j+k]);
+		}
+		j += n_elems;
+	}
+	fprintf(f, " };\n");
 
 	fclose(f);
 }

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -82,6 +82,14 @@ module SMIOLf
 
         integer(c_size_t) :: io_start;  ! The starting offset on disk for I/O by a task
         integer(c_size_t) :: io_count;  ! The number of elements for I/O by a task
+
+        integer(c_int) ::  agg_factor       ! Aggregation factor, or size of aggregation group
+        integer :: agg_comm                 ! Communicator for aggregation/deaggregation operations
+        integer(c_size_t) :: n_compute      ! Number of un-aggregated compute elements on the task
+        integer(c_size_t) :: n_compute_agg  ! Number of aggregated compute elements on the task
+        type (c_ptr) :: counts              ! Compute element counts for tasks in aggregation group
+        type (c_ptr) :: displs              ! Displacements in aggregated list of elements for tasks
+                                            !    in aggregation group
     end type SMIOLf_decomp
 
     interface SMIOLf_define_att


### PR DESCRIPTION
This PR implements the ability to aggregate (gather) fields across groups of MPI 
tasks before those fields are transferred from compute to I/O tasks, or to
deaggregate (scatter) fields after they are transferred from I/O to compute
tasks.

Also included in this PR are unit tests for the new I/O aggregation 
functionality.