### PR TITLE
Make use of a separate MPI communicator for I/O operations

### DIFF
--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -681,6 +681,14 @@ int test_open_close(FILE *test_log)
 		errcount++;
 	}
 
+#if 0
+/*
+ * Since members of the SMIOL_file struct may be used in various ways within
+ * SMIOL_close_file, and without being able to verify that the contents of the
+ * SMIOL_file are valid, this test may lead to segfaults or other crashes.
+ * Until we have a way of verifying the validity of a SMIOL_file before using
+ * its contents, this test should probably just be omitted.
+ */
 	/* Try to close a file that was never opened */
 	fprintf(test_log, "Try to close a file that was never opened: ");
 	file = (struct SMIOL_file *)malloc(sizeof(struct SMIOL_file));
@@ -694,6 +702,7 @@ int test_open_close(FILE *test_log)
 		fprintf(test_log, "FAIL - expected error code of SMIOL_LIBRARY_ERROR not returned\n");
 		errcount++;
 	}
+#endif
 
 	/* Create a file to be closed and opened again */
 	fprintf(test_log, "Create a file to be closed and later re-opened: ");
@@ -3446,6 +3455,14 @@ int test_file_sync(FILE *test_log)
 	}
 
 
+#if 0
+/*
+ * Since members of the SMIOL_file struct may be used in various ways within
+ * SMIOL_sync_file, and without being able to verify that the contents of the
+ * SMIOL_file are valid, this test may lead to segfaults or other crashes.
+ * Until we have a way of verifying the validity of a SMIOL_file before using
+ * its contents, this test should probably just be omitted.
+ */
 #ifdef SMIOL_PNETCDF
 	/* Testing a file that was never opened */
 	fprintf(test_log, "Try to sync a file that was never opened: ");
@@ -3461,6 +3478,7 @@ int test_file_sync(FILE *test_log)
 		errcount++;
 	}
 	free(file);
+#endif
 #endif
 
 	/* Testing SMIOL_sync_file with a NULL file pointer*/

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -510,9 +510,9 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
 {
 	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
-	int dimidp;
+	int dimidp = 0;
 	int ierr;
-	MPI_Offset len;
+	MPI_Offset len = 0;
 #endif
 	/*
 	 * Check that file handle is valid
@@ -582,7 +582,7 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
 	 * Inquire if this dimension is the unlimited dimension
 	 */
 	if (is_unlimited != NULL) {
-		int unlimdimidp;
+		int unlimdimidp = 0;
 		if (file->io_task) {
 			ierr = ncmpi_inq_unlimdim(file->ncidp, &unlimdimidp);
 		}
@@ -768,11 +768,11 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
 	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
 	int *dimids;
-	int varidp;
+	int varidp = 0;
 	int ierr;
 	int i;
 	int xtypep;
-	int ndimsp;
+	int ndimsp = 0;
 #endif
 
 	/*
@@ -1080,7 +1080,7 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 #ifdef SMIOL_PNETCDF
 	{
 		int j;
-		int varidp;
+		int varidp = 0;
 		const void *buf_p;
 		MPI_Offset *mpi_start;
 		MPI_Offset *mpi_count;
@@ -1287,7 +1287,7 @@ int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
 #ifdef SMIOL_PNETCDF
 	{
 		int j;
-		int varidp;
+		int varidp = 0;
 		void *buf_p;
 		MPI_Offset *mpi_start;
 		MPI_Offset *mpi_count;
@@ -1484,7 +1484,7 @@ int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
 	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
 	int ierr;
-	int varidp;
+	int varidp = 0;
 	nc_type xtype;
 #endif
 
@@ -1613,9 +1613,9 @@ int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
 	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
 	int ierr;
-	int varidp;
-	nc_type xtypep;
-	MPI_Offset lenp;
+	int varidp = 0;
+	nc_type xtypep = 0;
+	MPI_Offset lenp = 0;
 #endif
 
 	/*

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -412,8 +412,8 @@ int SMIOL_close_file(struct SMIOL_file **file)
  ********************************************************************************/
 int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int dimidp;
 	int ierr;
 	MPI_Offset len;
@@ -433,9 +433,9 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset 
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	/*
 	 * The parallel-netCDF library does not permit zero-length dimensions
 	 */
@@ -508,8 +508,8 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset 
 int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
                       SMIOL_Offset *dimsize, int *is_unlimited)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int dimidp = 0;
 	int ierr;
 	MPI_Offset len = 0;
@@ -543,9 +543,9 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
 		(*is_unlimited) = 0; /* Return 0 if no library provides a value */
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	if (file->io_task) {
 		ierr = ncmpi_inq_dimid(file->ncidp, dimname, &dimidp);
 	}
@@ -625,8 +625,8 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
  ********************************************************************************/
 int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, int ndims, const char **dimnames)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int *dimids;
 	int ierr;
 	int i;
@@ -659,9 +659,9 @@ int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, 
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	dimids = (int *)malloc(sizeof(int) * (size_t)ndims);
 	if (dimids == NULL) {
 		return SMIOL_MALLOC_FAILURE;
@@ -765,8 +765,8 @@ int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, 
  ********************************************************************************/
 int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int *dimids;
 	int varidp = 0;
 	int ierr;
@@ -807,9 +807,9 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
 		*ndims = 0;
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	/*
 	 * Get variable ID
 	 */
@@ -975,8 +975,6 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 	void *agg_buf = NULL;
 	const void *agg_buf_cnst = NULL;
 
-	MPI_Comm io_group_comm;
-
 
 	/*
 	 * Basic checks on arguments
@@ -984,8 +982,6 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 	if (file == NULL || varname == NULL) {
 		return SMIOL_INVALID_ARGUMENT;
 	}
-
-	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
 	/*
 	 * Work out the start[] and count[] arrays for writing this variable
@@ -1084,6 +1080,9 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 		const void *buf_p;
 		MPI_Offset *mpi_start;
 		MPI_Offset *mpi_count;
+		MPI_Comm io_group_comm;
+
+		io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
 		if (file->state == PNETCDF_DEFINE_MODE) {
 			if (file->io_task) {
@@ -1481,8 +1480,8 @@ int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
 int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
                      const char *att_name, int att_type, const void *att)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int ierr;
 	int varidp = 0;
 	nc_type xtype;
@@ -1495,14 +1494,14 @@ int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
-	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
-
 	/*
 	 * Checks for valid attribute type are handled in library-specific
 	 * code, below
 	 */
 
 #ifdef SMIOL_PNETCDF
+	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
+
 	/*
 	 * If varname was provided, get the variable ID; else, the attribute
 	 * is a global attribute not associated with a specific variable
@@ -1610,8 +1609,8 @@ int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
                       const char *att_name, int *att_type,
                       SMIOL_Offset *att_len, void *att)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int ierr;
 	int varidp = 0;
 	nc_type xtypep = 0;
@@ -1636,9 +1635,9 @@ int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
 		*att_type = SMIOL_UNKNOWN_VAR_TYPE;
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	/*
 	 * If varname was provided, get the variable ID; else, the inquiry is
 	 * is for a global attribute not associated with a specific variable
@@ -1753,8 +1752,8 @@ int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
  ********************************************************************************/
 int SMIOL_sync_file(struct SMIOL_file *file)
 {
-	MPI_Comm io_group_comm;
 #ifdef SMIOL_PNETCDF
+	MPI_Comm io_group_comm;
 	int ierr;
 #endif
 
@@ -1765,9 +1764,9 @@ int SMIOL_sync_file(struct SMIOL_file *file)
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
+#ifdef SMIOL_PNETCDF
 	io_group_comm = MPI_Comm_f2c(file->io_group_comm);
 
-#ifdef SMIOL_PNETCDF
 	/*
 	 * If the file is in define mode then switch it into data mode
 	 */

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -37,6 +37,13 @@ struct SMIOL_file {
 	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
 	int ncidp; /* parallel-netCDF file handle */
 #endif
+	int io_task; /* 1 = this task performs I/O calls
+	                0 = no I/O calls on this task */
+	MPI_Fint io_file_comm;  /* Communicator shared by all tasks with
+	                           io_task == 1 */
+	MPI_Fint io_group_comm; /* Communicator shared by tasks associated with
+	                           an I/O task, usually 1 I/O task and N-1
+	                           non-I/O tasks, where N is the I/O stride */
 };
 
 struct SMIOL_decomp {

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -63,6 +63,10 @@ module SMIOLf
         integer(c_int) :: state      ! parallel-netCDF file state (i.e. Define or data mode)
         integer(c_int) :: ncidp      ! parallel-netCDF file handle
 #endif
+        integer(c_int) :: io_task    ! 1 = this task performs I/O calls; 0 = no I/O calls on this task
+        integer :: io_file_comm      ! Communicator shared by all tasks with io_task == 1
+        integer :: io_group_comm     ! Communicator shared by tasks associated with an I/O task, usually 1 I/O task
+                                     ! and N-1 non-I/O tasks, where N is the I/O stride
     end type SMIOLf_file
 
     type, bind(C) :: SMIOLf_decomp


### PR DESCRIPTION
This PR introduces two new MPI communicators for I/O tasks and groups of tasks
associated with each I/O tasks, and it modifies the SMIOL code to use a separate
MPI communicator for I/O operations.

Previously, all MPI tasks performed I/O calls regardless of whether those tasks
actually read or wrote data. With the changes in this PR, only MPI tasks
identified as I/O tasks (i.e., with file->io_task == 1) actually make I/O calls
to the Parallel-NetCDF library, and the return error codes and read data are
broadcast from I/O tasks to all other non-I/O tasks in each I/O group.

Note: It should be possible to recover the behavior of SMIOL prior to this PR
in which all MPI tasks perform I/O calls by adding code like
```
    (*file)->io_task = 1;
    io_group = context->comm_rank;
```
around line 252 of smiol.c. This might be useful for testing or evaluation of
performance when restricting the set of MPI tasks that perform I/O calls.