### PR TITLE
Implement use of buffered, non-blocking write interface to Parallel-NetCDF

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -177,6 +177,18 @@ program smiol_runner
         write(test_log,'(a)') ''
     endif
 
+    !
+    ! Unit tests for buffered I/O
+    !
+    ierr = test_buffered_io(test_log)
+    if (ierr == 0) then
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
+    else
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
+    endif
+
     num_io_tasks = 16
     io_stride = 4
 
@@ -3298,6 +3310,364 @@ contains
         write(test_log,'(a)') ''
 
     end function test_io_aggregation
+
+
+    function test_buffered_io(test_log) result(ierrcount)
+
+        implicit none
+
+        integer, intent(in) :: test_log
+        integer :: ierrcount
+
+        integer :: ierr
+        integer :: comm_size, comm_rank
+        integer :: num_io_tasks, io_stride
+        type (SMIOLf_context), pointer :: context
+        type (SMIOLf_file), pointer :: file
+        character(len=32), dimension(2) :: dimnames
+        integer(kind=SMIOL_offset_kind) :: i, j
+        integer(kind=c_size_t) :: n_compute_elements
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: compute_elements
+        type (SMIOLf_decomp), pointer :: small_decomp, medium_decomp, large_decomp, null_decomp
+        integer, dimension(:), pointer :: small_var, medium_var, large_var
+
+
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '*************************** Buffered I/O tests *********************************'
+        write(test_log,'(a)') ''
+
+        ierrcount = 0
+
+        call MPI_Comm_rank(MPI_COMM_WORLD, comm_rank, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI rank...'
+            ierrcount = -1
+            return
+        end if
+
+        call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI size...'
+            ierrcount = -1
+            return
+        end if
+
+        if (comm_size > 1) then
+            num_io_tasks = comm_size / 2
+        else
+            num_io_tasks = 1
+        end if
+        io_stride = 2
+
+        !
+        ! Create a SMIOL context for testing buffered I/O
+        !
+        ierr = SMIOLf_init(MPI_COMM_WORLD, num_io_tasks, io_stride, context)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
+            write(test_log,'(a)') 'Failed to initalize a SMIOL context'
+            ierrcount = -1
+            return
+        end if
+
+        n_compute_elements = 1
+        allocate(compute_elements(n_compute_elements))
+        do i = 1, n_compute_elements
+            compute_elements(i) = (i - 1) + n_compute_elements * comm_rank
+        end do
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, small_decomp, aggregation_factor=1) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create small_decomp'
+            ierrcount = -1
+            return
+        end if
+        deallocate(compute_elements)
+
+        n_compute_elements = 2048
+        allocate(compute_elements(n_compute_elements))
+        do i = 1, n_compute_elements
+            compute_elements(i) = (i - 1) + n_compute_elements * comm_rank
+        end do
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, medium_decomp, aggregation_factor=1) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create medium_decomp'
+            ierrcount = -1
+            return
+        end if
+        deallocate(compute_elements)
+
+        n_compute_elements = 6000000
+        allocate(compute_elements(n_compute_elements))
+        do i = 1, n_compute_elements
+            compute_elements(i) = (i - 1) + n_compute_elements * comm_rank
+        end do
+        if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, large_decomp, aggregation_factor=1) &
+            /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create large_decomp'
+            ierrcount = -1
+            return
+        end if
+        deallocate(compute_elements)
+
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'buffered_write_f.nc', SMIOL_FILE_CREATE, file, bufsize=int(4*1024*1024, kind=c_size_t))
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to create a file for testing buffered I/O'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'Time', -1_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension Time...'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'small_dim', int(comm_size, kind=SMIOL_offset_kind)) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension small_dim...'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'medium_dim', int(2048 * comm_size, kind=SMIOL_offset_kind)) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension medium_dim...'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'large_dim', int(6000000 * comm_size, kind=SMIOL_offset_kind)) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension large_dim...'
+            ierrcount = -1
+            return
+        end if
+
+        dimnames(1) = 'small_dim'
+        dimnames(2) = 'Time'
+
+        if (SMIOLf_define_var(file, 'small_var', SMIOL_INT32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create small_var variable...'
+            ierrcount = -1
+            return
+        end if
+
+        dimnames(1) = 'medium_dim'
+        dimnames(2) = 'Time'
+        if (SMIOLf_define_var(file, 'medium_var', SMIOL_INT32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create medium_var variable...'
+            ierrcount = -1
+            return
+        end if
+
+        dimnames(1) = 'large_dim'
+        if (SMIOLf_define_var(file, 'large_var', SMIOL_INT32, 1, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create large_var variable...'
+            ierrcount = -1
+            return
+        end if
+
+        allocate(small_var(1))
+        allocate(medium_var(2048))
+        allocate(large_var(6000000))
+
+        do i = 1, 1
+            small_var(i) = int((i - 1) + 1 * comm_rank)
+        end do
+
+        do i = 1, 2048
+            medium_var(i) = int((i - 1) + 2048 * comm_rank)
+        end do
+
+        do i = 1, 6000000
+            large_var(i) = int((i - 1) + 6000000 * comm_rank)
+        end do
+
+        ! Write a small variable that should fit within buffer
+        write(test_log,'(a)',advance='no') 'Write a small variable that should fit within buffer: '
+        ierr = SMIOLf_put_var(file, 'small_var', small_decomp, small_var)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - '//trim(SMIOLf_error_string(ierr))
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Write more variables than available pending requests
+        write(test_log,'(a)',advance='no') 'Write more variables than available pending requests: '
+        do i = 1, 300
+            ierr = SMIOLf_set_frame(file, i-1)
+            if (ierr /= SMIOL_SUCCESS) then
+                exit
+            end if
+
+            ierr = SMIOLf_put_var(file, 'small_var', small_decomp, small_var)
+            if (ierr /= SMIOL_SUCCESS) then
+                exit
+            end if
+        end do
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - '//trim(SMIOLf_error_string(ierr))
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Synchronize a file with buffered writes
+        write(test_log,'(a)',advance='no') 'Synchronize a file with buffered writes: '
+        ierr = SMIOLf_sync_file(file);
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - '//trim(SMIOLf_error_string(ierr))
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Write variables to simultaneously exceed all requests and buffer space
+        write(test_log,'(a)',advance='no') 'Write variables to simultaneously exceed all requests and buffer space: '
+        do i = 1, 257
+            ierr = SMIOLf_set_frame(file, i-1)
+            if (ierr /= SMIOL_SUCCESS) then
+                exit
+            end if
+
+            ierr = SMIOLf_put_var(file, 'medium_var', medium_decomp, medium_var)
+            if (ierr /= SMIOL_SUCCESS) then
+                exit
+            end if
+        end do
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - '//trim(SMIOLf_error_string(ierr))
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Write a single variable that should exceed buffer space
+        write(test_log,'(a)',advance='no') 'Write a single variable that should exceed buffer space: '
+        ierr = SMIOLf_put_var(file, 'large_var', large_decomp, large_var)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - '//trim(SMIOLf_error_string(ierr))
+            ierrcount = ierrcount + 1
+        end if
+
+        deallocate(small_var)
+        deallocate(medium_var)
+        deallocate(large_var)
+
+        nullify(null_decomp)
+
+        ! Read back and verify large variable
+        write(test_log,'(a)',advance='no') 'Read back and verify large variable: '
+        allocate(large_var(6000000 * comm_size))
+        large_var(:) = 0
+        ierr = SMIOLf_get_var(file, 'large_var', null_decomp, large_var)
+        if (ierr == SMIOL_SUCCESS) then
+            do i = 1, 6000000 * comm_size
+                if (large_var(i) /= int(i-1)) then
+                    ierr = not(SMIOL_SUCCESS)
+                    exit
+                end if
+            end do
+        end if
+
+        deallocate(large_var)
+
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Read back and verify medium variable
+        write(test_log,'(a)',advance='no') 'Read back and verify medium variable: '
+        allocate(medium_var(2048 * comm_size))
+        MEDIUM_LOOP: do j = 1, 257
+            ierr = SMIOLf_set_frame(file, j-1)
+            if (ierr /= SMIOL_SUCCESS) exit
+
+            medium_var(:) = 0
+            ierr = SMIOLf_get_var(file, 'medium_var', null_decomp, medium_var)
+            if (ierr == SMIOL_SUCCESS) then
+                do i = 1, 2048 * comm_size
+                    if (medium_var(i) /= int(i-1)) then
+                        ierr = not(SMIOL_SUCCESS)
+                        exit MEDIUM_LOOP
+                    end if
+                end do
+            end if
+        end do MEDIUM_LOOP
+
+        deallocate(medium_var)
+
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Read back and verify small variable
+        write(test_log,'(a)',advance='no') 'Read back and verify small variable: '
+        allocate(small_var(comm_size))
+        SMALL_LOOP: do j = 1, 300
+            ierr = SMIOLf_set_frame(file, j-1)
+            if (ierr /= SMIOL_SUCCESS) exit
+
+            small_var(:) = 0
+            ierr = SMIOLf_get_var(file, 'small_var', null_decomp, small_var)
+            if (ierr == SMIOL_SUCCESS) then
+                do i = 1, comm_size
+                    if (small_var(i) /= int(i-1)) then
+                        ierr = not(SMIOL_SUCCESS)
+                        exit SMALL_LOOP
+                    end if
+                end do
+            end if
+        end do SMALL_LOOP
+
+        deallocate(small_var)
+
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL'
+            ierrcount = ierrcount + 1
+        end if
+
+        if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to close file for buffered I/O tests'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_free_decomp(small_decomp) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free small_decomp'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_free_decomp(medium_decomp) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free medium_decomp'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_free_decomp(large_decomp) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to free large_decomp'
+            ierrcount = -1
+            return
+        end if
+
+        ierr = SMIOLf_finalize(context)
+        if (ierr /= SMIOL_SUCCESS .or. associated(context)) then
+            ierrcount = -1
+            return
+        end if
+
+        write(test_log,'(a)') ''
+
+    end function test_buffered_io
 
 
     !-----------------------------------------------------------------------

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_open_file(context, "blah.nc", SMIOL_FILE_CREATE, &file)) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_open_file(context, "blah.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_open_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
@@ -647,7 +647,7 @@ int test_open_close(FILE *test_log)
 	/* Try to open a file with an invalid mode */
 	fprintf(test_log, "Try to open a file with an invalid mode: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "smiol_invalid.nc", ~(SMIOL_FILE_CREATE | SMIOL_FILE_WRITE | SMIOL_FILE_READ), &file);
+	ierr = SMIOL_open_file(context, "smiol_invalid.nc", ~(SMIOL_FILE_CREATE | SMIOL_FILE_WRITE | SMIOL_FILE_READ), &file, (size_t)64000000);
 	if (ierr == SMIOL_INVALID_ARGUMENT && file == NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -660,7 +660,7 @@ int test_open_close(FILE *test_log)
 	/* Try to create a file for which we should not have sufficient permissions */
 	fprintf(test_log, "Try to create a file with insufficient permissions: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "/smiol_test.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "/smiol_test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr == SMIOL_LIBRARY_ERROR && file == NULL) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
 	}
@@ -672,7 +672,7 @@ int test_open_close(FILE *test_log)
 	/* Try to open a file that does not exist */
 	fprintf(test_log, "Try to open a non-existent file: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "/smiol_foobar.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "/smiol_foobar.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr == SMIOL_LIBRARY_ERROR && file == NULL) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
 	}
@@ -707,7 +707,7 @@ int test_open_close(FILE *test_log)
 	/* Create a file to be closed and opened again */
 	fprintf(test_log, "Create a file to be closed and later re-opened: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -730,7 +730,7 @@ int test_open_close(FILE *test_log)
 	/* Re-open the file with read access */
 	fprintf(test_log, "Re-open file with read access: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -753,7 +753,7 @@ int test_open_close(FILE *test_log)
 	/* Re-open the file with write access */
 	fprintf(test_log, "Re-open file with write access: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_WRITE, &file);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -777,7 +777,7 @@ int test_open_close(FILE *test_log)
 	/* Everything OK (SMIOL_open_file) */
 	fprintf(test_log, "Everything OK (SMIOL_open_file): ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -2069,7 +2069,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Create a SMIOL file for testing dimension routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -2296,7 +2296,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open existing SMIOL file...\n");
 		return -1;
@@ -2423,7 +2423,7 @@ int test_variables(FILE *test_log)
 
 	/* Create a SMIOL file for testing variable routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -2714,7 +2714,7 @@ int test_variables(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to re-open SMIOL file...\n");
 		return -1;
@@ -2910,7 +2910,7 @@ int test_attributes(FILE *test_log)
 
 	/* Create a SMIOL file for testing attribute routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -3145,7 +3145,7 @@ int test_attributes(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to re-open SMIOL file...\n");
 		return -1;
@@ -3364,7 +3364,7 @@ int test_file_sync(FILE *test_log)
 	}
 
 	/* Open a file for syncing */
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sycn_file.nc\n");
 		return -1;
@@ -3395,7 +3395,7 @@ int test_file_sync(FILE *test_log)
 
 
 	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_WRITE */
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_WRITE, &file);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc in write mode\n");
 		return -1;
@@ -3425,7 +3425,7 @@ int test_file_sync(FILE *test_log)
 	}
 
 	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_READ*/
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc with SMIOL_FILE_READ\n");
 		return -1;
@@ -4460,7 +4460,7 @@ int test_set_get_frame(FILE* test_log)
 	/* See if the frame is set correctly when opening a file */
 	fprintf(test_log, "Everything OK - Frame set correct on file open: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_frame.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_frame.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -4675,7 +4675,7 @@ int test_put_get_vars(FILE *test_log)
 
 	/* Create a SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -5058,7 +5058,7 @@ int test_put_get_vars(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -5560,7 +5560,7 @@ int test_io_aggregation(FILE *test_log)
 	 * Create a new file, to which we will write using all three of the decompositions from above
 	 */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_CREATE, &file);
+	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create a file for testing aggregation\n");
 		return -1;
@@ -5654,7 +5654,7 @@ int test_io_aggregation(FILE *test_log)
 	}
 
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_READ, &file);
+	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_READ, &file, (size_t)0);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open file that was created for testing aggregation\n");
 		return -1;

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -20,7 +20,8 @@ int SMIOL_inquire(void);
 /*
  * File methods
  */
-int SMIOL_open_file(struct SMIOL_context *context, const char *filename, int mode, struct SMIOL_file **file);
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
+                    int mode, struct SMIOL_file **file, size_t bufsize);
 int SMIOL_close_file(struct SMIOL_file **file);
 
 /*

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -36,6 +36,9 @@ struct SMIOL_file {
 #ifdef SMIOL_PNETCDF
 	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
 	int ncidp; /* parallel-netCDF file handle */
+	size_t bufsize; /* Size of buffer attached to this file */
+	int n_reqs;  /* Number of pending non-blocking requests */
+	int *reqs;   /* Array of pending non-blocking request handles */
 #endif
 	int io_task; /* 1 = this task performs I/O calls
 	                0 = no I/O calls on this task */


### PR DESCRIPTION
This PR implements the use of the buffered, non-blocking write interface to Parallel-NetCDF.

With this PR, calls to SMIOL(f)_put_var now attempt to use the non-blocking,
buffered write routine ncmpi_bput_vara to write fields to a file whenever
possible. When opening files with SMIOL(f)_open_file, a new 'bufsize' argument
is used to specify the size in bytes of the buffer to attach to the file, and
this new bufsize argument is only used when the file is opened with a mode of
SMIOL_FILE_CREATE or SMIOL_FILE_WRITE.

Also included in this PR are tests of the buffered write capability in the smiol_runner.c
and smiol_runner.F90 test programs.