### PR TITLE
Fix bug when inquiring about dimension names with non-unit I/O stride

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -1548,6 +1548,12 @@ contains
         call MPI_Comm_size(MPI_COMM_WORLD, num_io_tasks, ierr)
         io_stride = 1
 
+        ! If more than one MPI rank, use an io_stride of 2
+        if (num_io_tasks > 1) then
+            io_stride = 2
+            num_io_tasks = num_io_tasks / io_stride
+        end if
+
         ! Create a SMIOL context for testing file variable routines
         nullify(context)
         ierr = SMIOLf_init(MPI_COMM_WORLD, num_io_tasks, io_stride, context)

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -2425,6 +2425,12 @@ int test_variables(FILE *test_log)
 	MPI_Comm_size(MPI_COMM_WORLD, &num_io_tasks);
 	io_stride = 1;
 
+	/* If more than one MPI rank, use an io_stride of 2 */
+	if (num_io_tasks > 1) {
+		io_stride = 2;
+		num_io_tasks = num_io_tasks / io_stride;
+	}
+
 	/* Create a SMIOL context for testing variable routines */
 	context = NULL;
 	ierr = SMIOL_init(MPI_COMM_WORLD, num_io_tasks, io_stride, &context);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -995,6 +995,7 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
 			if (file->io_task) {
 				len = (int)strnlen(dimnames[i],
 				                   (size_t)NC_MAX_NAME);
+				len++; /* Include the terminating '\0' character */
 			}
 			MPI_Bcast(&len, 1, MPI_INT, 0, io_group_comm);
 			MPI_Bcast(dimnames[i], len, MPI_CHAR, 0, io_group_comm);


### PR DESCRIPTION
This PR fixes a bug that caused dimension names to be returned incorrectly on
non-I/O tasks.

When the I/O stride is larger than 1, the SMIOL_inquire_var routine must
broadcast values read from the file by I/O tasks to non-I/O tasks. In the case
of dimension names, the SMIOL_inquire_var routine previously broadcast each
dimension name with a broadcast size of 'len' characters, where len is the 
result of a call to strnlen. Since the strnlen function returns the length of a
string excluding the terminating null character, dimension names were broadcast
to non-I/O tasks without a terminating null character, resulting in incorrect
strings on non-I/O tasks. The simple fix for this is to increment the string
length, 'len', before using it as the size of the broadcast for dimension names.

Also included in this PR are updates to the unit tests for SMIOL(f)_inquire_var
(as well as other SMIOL variable routines) in the C and Fortran 'test_variables' 
functions so that a non-unit I/O stride is used for file access. The purpose of
this change is to catch future errors in which returned values, e.g., for
dimnames, are incorrect on non-I/O tasks. With the unit-stride file access used
in these tests prior to this commit, all tasks read/wrote values to a file, and
non-unit-stride correctness was therefore not tested.